### PR TITLE
Removes pausableBindUI, pausableBind

### DIFF
--- a/Example/SimpleTwoWayBindingExampleTests/SimpleTwoWayBindingReceiptBagTests.swift
+++ b/Example/SimpleTwoWayBindingExampleTests/SimpleTwoWayBindingReceiptBagTests.swift
@@ -19,10 +19,12 @@ class SimpleTwoWayBindingReceiptBagTests: XCTestCase {
         var pBindingFired = false
         
         o
-            .pausableBind(replay: false) { _ in oBindingFired = true }
+            .pausable
+            .bind(replay: false) { _ in oBindingFired = true }
             .add(to: bag)
         p
-            .pausableBind(replay: false) { _ in pBindingFired = true }
+            .pausable
+            .bind(replay: false) { _ in pBindingFired = true }
             .add(to: bag)
         
         o.value = 2
@@ -57,7 +59,8 @@ class SimpleTwoWayBindingReceiptBagTests: XCTestCase {
         var oBindingFired = false
         
         o
-            .pausableBind(replay: false) { _ in oBindingFired = true }
+            .pausable
+            .bind(replay: false) { _ in oBindingFired = true }
             .add(to: bag)
         
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)

--- a/Sources/Observable.swift
+++ b/Sources/Observable.swift
@@ -58,14 +58,17 @@ public struct PausableReceipt {
     public func add(to bag: ReceiptBag) { bag.receipts.append(self) }
 }
 
-public class Observable<ObservedType> {
+public class Observable<ObservedType>: Identifiable {
+    public let id = UUID()
     public typealias Observer = (_ observable: Observable<ObservedType>, ObservedType) -> Void
     
     /// Map of receipt objects to the binding blocks those objects represent; see bind(observer:) and unbind(:)
-    private var observers: [BindingReceipt: Observer] = [:]
+    fileprivate var observers: [BindingReceipt: Observer] = [:]
     /// Map of other observers we've been bound to; see map(:) & other functional conveniences. This allows us to hold strong references to the anonymous observables generated in a chained series of calls, and break them when needed.
-    private var bindings: [BindingReceipt: () -> Void] = [:]
+    fileprivate var bindings: [BindingReceipt: () -> Void] = [:]
     
+    public var pausable: PausableObservable<ObservedType> { PausableObservable(self) }
+     
     public var value: ObservedType? {
         didSet {
             if let value = value {
@@ -85,14 +88,6 @@ public class Observable<ObservedType> {
         return r
     }
     
-    public func pausableBind(observer: @escaping Observer) -> PausableReceipt {
-        PausableReceipt(
-            receipt: bind(observer: observer),
-            unbind: unbind,
-            pauseObservations: pauseObservations,
-            unpauseObservations: unpauseObservations)
-    }
-    
     public func setObserving(_ referenceHolder: @escaping () -> Void, receipt: BindingReceipt) {
         bindings[receipt] = referenceHolder
     }
@@ -106,16 +101,52 @@ public class Observable<ObservedType> {
         bindings[r] = nil
     }
     
-    private func notifyObservers(_ value: ObservedType) {
+    fileprivate func notifyObservers(_ value: ObservedType) {
         observers.values.forEach { [unowned self] observer in
-            guard paused == false else { return }
             observer(self, value)
         }
+    }
+}
+
+public class PausableObservable<ObservedType>: Observable<ObservedType> {
+    init(_ observable: Observable<ObservedType>) {
+        super.init()
+        value = observable.value
+        observers = observable.observers
+        bindings = observable.bindings
+    }
+    
+    public func bind(replay: Bool = true, on queue: DispatchQueue? = .main, _ f: @escaping (ObservedType) -> Void) -> PausableReceipt {
+        PausableReceipt(
+            receipt: super.bind(replay: replay, on: queue, f),
+            unbind: unbind,
+            pauseObservations: pauseObservations,
+            unpauseObservations: unpauseObservations
+        )
+    }
+    
+    public func bind<Root: AnyObject>(replay: Bool = true, on queue: DispatchQueue? = nil, _ target: inout Root, _ path: WritableKeyPath<Root, ObservedType>) -> PausableReceipt {
+        PausableReceipt(
+            receipt: super.bind(replay: replay, on: queue, &target, path),
+            unbind: unbind,
+            pauseObservations: pauseObservations,
+            unpauseObservations: unpauseObservations
+        )
+    }
+    
+    override func notifyObservers(_ value: ObservedType) {
+        guard paused == false else { return }
+        super.notifyObservers(value)
     }
     
     private var paused: Bool = false
     
     public func pauseObservations() { paused = true }
-    public func unpauseObservations() { paused = false }
+    
+    public func unpauseObservations() {
+        paused = false
+        if let value = value {
+            notifyObservers(value)
+        }
+    }
 }
-


### PR DESCRIPTION
…in favor of a `pausable` property and a way to specify queues in the `bind` call.

Also adds a key path based `bind`, for simpler setters, and the `trigger` method on `Observable<Void>`.