### PR TITLE
Some simplification of the bind api

### DIFF
--- a/Example/SimpleTwoWayBindingExampleTests/SimpleTwoWayBindingReceiptBagTests.swift
+++ b/Example/SimpleTwoWayBindingExampleTests/SimpleTwoWayBindingReceiptBagTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class SimpleTwoWayBindingReceiptBagTests: XCTestCase {
     func testPauseUnpause() {
-        let bag = ReceiptBag()
+        let bag = ReceiptBag(handleBackgroundNotifications: false)
         let o: Observable<Int> = Observable(1)
         let p: Observable<Bool> = Observable(false)
         
@@ -42,6 +42,13 @@ class SimpleTwoWayBindingReceiptBagTests: XCTestCase {
         XCTAssertFalse(pBindingFired)
 
         bag.unpause()
+        
+        // Bags always replay the last values into the bindings after an unpause
+        XCTAssert(oBindingFired)
+        XCTAssert(pBindingFired)
+
+        oBindingFired = false
+        pBindingFired = false
         
         o.value = 4
         p.value = true

--- a/Sources/Observable+FunctionalConvenience.swift
+++ b/Sources/Observable+FunctionalConvenience.swift
@@ -9,52 +9,47 @@
 import Foundation
 
 public extension Observable {
-    /// Bind to this observable with a simple value function, optionally replaying the existing value into the stream immediately
+
+/// Bind to this observable with a simple value function, optionally replaying the existing value into the stream immediately
     ///
     /// This is a nice alternative to the standard `bind((Observable<ObservedType>, ObservedType)->Void)`, since we're 99% of the time uninterested in getting a reference to the Observable itself.
     /// - Parameters:
     ///   - replay: If there's a value in this observable, after setting up the binding immediately fire the observation function with that value, rather than the default behavior of waiting for a new value to come into the stream. Defaults to true.
+    ///   - queue: (Optional) Queue to run the binding function on when it fires; nil runs on whatever queue the value was set from. Defaults to nil.
     ///   - f: an observation function
     @discardableResult
-    func bind(replay: Bool = true, _ f: @escaping (ObservedType) -> Void) -> BindingReceipt {
-        let r = bind { _, value in f(value) }
+    func bind(replay: Bool = true, on queue: DispatchQueue? = nil, _ f: @escaping (ObservedType) -> Void) -> BindingReceipt {
+        let wrappedF: (ObservedType) -> Void = { value in
+            if let queue = queue {
+                if queue == DispatchQueue.main, Thread.isMainThread {
+                    f(value)
+                } else {
+                    queue.async {
+                        f(value)
+                    }
+                }
+            } else {
+                f(value)
+            }
+        }
+        let r = bind { _, value in
+            wrappedF(value)
+        }
         if replay, let value = value {
-            f(value)
+            wrappedF(value)
         }
         return r
     }
     
-    func pausableBind(replay: Bool = true, _ f: @escaping (ObservedType) -> Void) -> PausableReceipt {
-        PausableReceipt(
-            receipt: bind(replay: replay, f),
-            unbind: unbind,
-            pauseObservations: pauseObservations,
-            unpauseObservations: unpauseObservations
-        )
-    }
-    
+    /// Bind to this observable with an object/keypath pair
+    /// - Parameters:
+    ///   - replay: If there's a value in this observable, after setting up the binding immediately fire the observation function with that value, rather than the default behavior of waiting for a new value to come into the stream. Defaults to true.
+    ///   - queue: (Optional) Queue to run the binding function on when it fires; nil runs on whatever queue the value was set from. Defaults to nil.
+    ///   - target: object to use writeable keypath on
+    ///   - path: a writeable keypath to a property of the target to set
     @discardableResult
-    func bindUI(replay: Bool = true, _ f: @escaping (ObservedType) -> Void) -> BindingReceipt {
-        let r: BindingReceipt = bind { _, value in
-            DispatchQueue.main.async {
-                f(value)
-            }
-        }
-        if replay, let value = value {
-            DispatchQueue.main.async {
-                f(value)
-            }
-        }
-        return r
-    }
-    
-    func pausableBindUI(replay: Bool = true, _ f: @escaping (ObservedType) -> Void) -> PausableReceipt {
-        PausableReceipt(
-            receipt: bindUI(replay: replay, f),
-            unbind: unbind,
-            pauseObservations: pauseObservations,
-            unpauseObservations: unpauseObservations
-        )
+    func bind<Root: AnyObject>(replay: Bool = true, on queue: DispatchQueue? = nil, _ target: inout Root, _ path: WritableKeyPath<Root, ObservedType>) -> BindingReceipt {
+        bind(replay: replay, on: queue) { [weak target] value in target?[keyPath: path] = value }
     }
     
     /// Create a new observable whose value is mapped from this observable's values

--- a/Sources/Observable.swift
+++ b/Sources/Observable.swift
@@ -8,54 +8,10 @@
 import Foundation
 import UIKit
 
-/// A helper class to manage pausable receipts
-public class ReceiptBag {
-    public var receipts: [PausableReceipt] = []
-    
-    /// Pause observations in all receipts we're holding
-    public func pause() { receipts.forEach { $0.pauseObservations() } }
-    
-    /// Unpause observations in all receipts we're holding
-    public func unpause() { receipts.forEach { $0.unpauseObservations() } }
-    
-    private var handleBackgroundNotifications = true
-    private var observers: [NSObjectProtocol] = []
-    
-    /// - Parameter handleBackgroundNotifications: When true, this bag will automatically sign up for iOS background/foreground notifications; when those are triggered, the bag's receipts will be paused and unpaused
-    public init(handleBackgroundNotifications: Bool = true) {
-        self.handleBackgroundNotifications = handleBackgroundNotifications
-        
-        if handleBackgroundNotifications {
-            observers = [
-                NotificationCenter.default.addObserver(
-                    forName: UIApplication.didEnterBackgroundNotification,
-                    object: nil, queue: nil
-                ) { [weak self] _ in self?.pause() },
-                NotificationCenter.default.addObserver(
-                    forName: UIApplication.didBecomeActiveNotification,
-                    object: nil, queue: nil
-                ) { [weak self] _ in self?.unpause() }
-            ]
-        }
-    }
-    
-    deinit { observers.forEach(NotificationCenter.default.removeObserver) }
-}
-
 public struct BindingReceipt: Hashable, Identifiable {
     public let id = UUID()
     public func hash(into hasher: inout Hasher) { hasher.combine(id) }
     public static func == (lhs: BindingReceipt, rhs: BindingReceipt) -> Bool { lhs.id == rhs.id }
-}
-
-public struct PausableReceipt {
-    public let receipt: BindingReceipt
-    
-    public var unbind: (BindingReceipt) -> Void
-    public var pauseObservations: () -> Void
-    public var unpauseObservations: () -> Void
-     
-    public func add(to bag: ReceiptBag) { bag.receipts.append(self) }
 }
 
 public class Observable<ObservedType> {
@@ -65,6 +21,8 @@ public class Observable<ObservedType> {
     private var observers: [BindingReceipt: Observer] = [:]
     /// Map of other observers we've been bound to; see map(:) & other functional conveniences. This allows us to hold strong references to the anonymous observables generated in a chained series of calls, and break them when needed.
     private var bindings: [BindingReceipt: () -> Void] = [:]
+    
+    internal var paused: Bool = false
     
     public var value: ObservedType? {
         didSet {
@@ -85,14 +43,6 @@ public class Observable<ObservedType> {
         return r
     }
     
-    public func pausableBind(observer: @escaping Observer) -> PausableReceipt {
-        PausableReceipt(
-            receipt: bind(observer: observer),
-            unbind: unbind,
-            pauseObservations: pauseObservations,
-            unpauseObservations: unpauseObservations)
-    }
-    
     public func setObserving(_ referenceHolder: @escaping () -> Void, receipt: BindingReceipt) {
         bindings[receipt] = referenceHolder
     }
@@ -106,16 +56,14 @@ public class Observable<ObservedType> {
         bindings[r] = nil
     }
     
-    private func notifyObservers(_ value: ObservedType) {
+    internal func notifyObservers(_ value: ObservedType) {
         observers.values.forEach { [unowned self] observer in
             guard paused == false else { return }
             observer(self, value)
         }
     }
     
-    private var paused: Bool = false
     
-    public func pauseObservations() { paused = true }
-    public func unpauseObservations() { paused = false }
+    
 }
 

--- a/Sources/PausableObservable.swift
+++ b/Sources/PausableObservable.swift
@@ -1,0 +1,83 @@
+//
+//  PausableObservable.swift
+//  Pods-SimpleTwoWayBindingExample
+//
+//  Created by Ryan Forsythe on 6/15/20.
+//
+
+import Foundation
+
+/// A helper class to manage pausable receipts
+public class ReceiptBag {
+    public var receipts: [PausableReceipt] = []
+    
+    /// Pause observations in all receipts we're holding
+    public func pause() { receipts.forEach { $0.pauseObservations() } }
+    
+    /// Unpause observations in all receipts we're holding
+    public func unpause() { receipts.forEach { $0.unpauseObservations() } }
+    
+    private var handleBackgroundNotifications = true
+    private var observers: [NSObjectProtocol] = []
+    
+    /// - Parameter handleBackgroundNotifications: When true, this bag will automatically sign up for iOS background/foreground notifications; when those are triggered, the bag's receipts will be paused and unpaused
+    public init(handleBackgroundNotifications: Bool = true) {
+        self.handleBackgroundNotifications = handleBackgroundNotifications
+        
+        if handleBackgroundNotifications {
+            observers = [
+                NotificationCenter.default.addObserver(
+                    forName: UIApplication.didEnterBackgroundNotification,
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.pause() },
+                NotificationCenter.default.addObserver(
+                    forName: UIApplication.didBecomeActiveNotification,
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.unpause() }
+            ]
+        }
+    }
+    
+    deinit { observers.forEach(NotificationCenter.default.removeObserver) }
+}
+
+public struct PausableReceipt {
+    public let receipt: BindingReceipt
+    
+    public var unbind: (BindingReceipt) -> Void
+    public var pauseObservations: () -> Void
+    public var unpauseObservations: () -> Void
+     
+    public func add(to bag: ReceiptBag) { bag.receipts.append(self) }
+}
+
+extension Observable {
+    public func pauseObservations() { paused = true }
+    public func unpauseObservations() {
+        paused = false
+        if let value = value {
+            notifyObservers(value)
+        }
+    }
+    
+    public func pausableBind(observer: @escaping Observer) -> PausableReceipt {
+        PausableReceipt(
+            receipt: bind(observer: observer),
+            unbind: unbind,
+            pauseObservations: pauseObservations,
+            unpauseObservations: unpauseObservations)
+    }
+    
+    public func pausableBind(replay: Bool = true, on queue: DispatchQueue? = nil, _ f: @escaping (ObservedType) -> Void) -> PausableReceipt {
+        PausableReceipt(
+            receipt: bind(replay: replay, on: queue, f),
+            unbind: unbind,
+            pauseObservations: pauseObservations,
+            unpauseObservations: unpauseObservations
+        )
+    }
+    
+    public func pausableBind<Root: AnyObject>(replay: Bool = true, on queue: DispatchQueue? = nil, _ target: inout Root, _ path: WritableKeyPath<Root, ObservedType>) -> PausableReceipt {
+        pausableBind(replay: replay, on: queue) { [weak target] value in target?[keyPath: path] = value }
+    }
+}


### PR DESCRIPTION
It's not what I'd like the API to be, but it's what we can have in the context of S2WB.

* Remove "UI" variants of bind, in favor of an explicit dispatch queue
* Split out the pausable-related stuff into a separate file
* Add a key path bind method

(Apologies for the multiple PRs related to this today, I thought the earlier PR was working but it had too many problems when I started using it.)