### PR TITLE
Add a fire() function, which will notify observers of the current value

### DIFF
--- a/Sources/Observable.swift
+++ b/Sources/Observable.swift
@@ -25,10 +25,13 @@ public class Observable<ObservedType> {
     internal var paused: Bool = false
     
     public var value: ObservedType? {
-        didSet {
-            if let value = value {
-                notifyObservers(value)
-            }
+        didSet { fire() }
+    }
+    
+    /// Notify all observers with the current value if non-nil.
+    public func fire() {
+        if let value = value {
+            notifyObservers(value)
         }
     }
     


### PR DESCRIPTION
Adds a simple mechanism to notify all observers and fire their bindings.

* Useful for causing binding closures to run.
* Can be demonstrated with PR https://github.com/ridewithgps/RWGPS-iOS/pull/4983